### PR TITLE
fix: get media type is not parsed correctly

### DIFF
--- a/plugins/plugin-http-shell/src/lib/cmds/requests.ts
+++ b/plugins/plugin-http-shell/src/lib/cmds/requests.ts
@@ -279,7 +279,8 @@ export async function url(
             ? res.headers['content-type']
             : 'json';
 
-            const ct = _ct === 'application/json' || _ct === 'application/hal+json' ? 'json' : _ct;
+        const mediaType = _ct.split(';')[0]
+        const ct = mediaType === 'application/json' || mediaType === 'application/hal+json' ? 'json' : mediaType;
 
         if (res.text) {
           ret.modes.push({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@kui-shell/builder/tsconfig-base.json",
   "references": [
-    { "path": "./plugins/plugin-client-default" },
-    { "path": "./plugins/plugin-http-shell" }
+    { "path": "./plugins/plugin-http-shell" },
+    { "path": "./plugins/plugin-client-default" }
   ]
 }


### PR DESCRIPTION
Also fixes the wrong ordering in tsconfig.json


Screenshot 1 shows how body with json mediaType be color-coded and formatted correctly. 

Screenshot 2 shows the experiment I did on http-shell `get` and `help http-shell` command with inline-sidecar and split. 

Screenshot 3 shows that, with my fix, body with html/text mediaType will be rendered as html. 

**Screenshot 1:**
![Screen Shot 2020-10-21 at 2 57 17 PM](https://user-images.githubusercontent.com/21212160/96770834-da249580-13ae-11eb-88fb-1e814c425f4e.png)

**Screenshot 2:**
![Screen Shot 2020-10-21 at 2 56 36 PM](https://user-images.githubusercontent.com/21212160/96771996-726f4a00-13b0-11eb-9080-e98ee1b8fa30.png)


**Screenshot 3:**
![Screen Shot 2020-10-21 at 2 16 30 PM](https://user-images.githubusercontent.com/21212160/96771736-186e8480-13b0-11eb-97c1-048c56d55dc7.png)
